### PR TITLE
fix: Read the InputStream into a String

### DIFF
--- a/src/test/java/org/apache/camel/component/atlasmap/AtlasEndpointTest.java
+++ b/src/test/java/org/apache/camel/component/atlasmap/AtlasEndpointTest.java
@@ -1,0 +1,46 @@
+package org.apache.camel.component.atlasmap;
+
+import java.util.List;
+
+import io.atlasmap.v2.AtlasMapping;
+import io.atlasmap.v2.DataSource;
+import io.atlasmap.v2.DataSourceType;
+
+import org.junit.Test;
+
+import static org.apache.camel.component.atlasmap.AtlasEndpoint.isSourceXmlOrJson;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AtlasEndpointTest {
+
+    @Test
+    public void shouldDetectIfSourceIsXmlOrJson() {
+        final AtlasMapping mapping = new AtlasMapping();
+
+        assertFalse("With no datasources no XML or JSON sources should be found", isSourceXmlOrJson(mapping));
+
+        final List<DataSource> dataSources = mapping.getDataSource();
+        final DataSource dataSource = new DataSource();
+        dataSource.setDataSourceType(DataSourceType.SOURCE);
+        dataSources.add(dataSource);
+
+        assertFalse("Source datasource without uri should not be detected as XML or JSON", isSourceXmlOrJson(mapping));
+
+        dataSource.setUri("atlas:java:some.Type");
+        assertFalse("Java source datasource should not be detected as XML or JSON", isSourceXmlOrJson(mapping));
+
+        dataSource.setUri("atlas:json:SomeType");
+        assertTrue("JSON data source should be detected", isSourceXmlOrJson(mapping));
+
+        dataSource.setDataSourceType(DataSourceType.TARGET);
+        assertFalse("JSON data source target should not be detected as XML or JSON", isSourceXmlOrJson(mapping));
+
+        dataSource.setDataSourceType(DataSourceType.SOURCE);
+        dataSource.setUri("atlas:xml?complexType=ns:SomeElement");
+        assertTrue("XML data source should be detected", isSourceXmlOrJson(mapping));
+
+        dataSource.setDataSourceType(DataSourceType.TARGET);
+        assertFalse("XML data source target should not be detected as XML or JSON", isSourceXmlOrJson(mapping));
+    }
+}

--- a/src/test/java/org/apache/camel/component/atlasmap/AtlasMapComponentJsonToJavaTest.java
+++ b/src/test/java/org/apache/camel/component/atlasmap/AtlasMapComponentJsonToJavaTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.atlasmap;
+
+import java.io.ByteArrayInputStream;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.CamelSpringRunner;
+import org.apache.camel.test.spring.CamelTestContextBootstrapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(CamelSpringRunner.class)
+@BootstrapWith(CamelTestContextBootstrapper.class)
+@ContextConfiguration
+public class AtlasMapComponentJsonToJavaTest {
+    @Autowired
+    protected CamelContext camelContext;
+
+    @EndpointInject(uri = "mock:result")
+    protected MockEndpoint result;
+
+    @Test
+    @DirtiesContext
+    public void testMocksAreValid() throws Exception {
+        result.setExpectedCount(1);
+
+        final ProducerTemplate producerTemplate = camelContext.createProducerTemplate();
+        producerTemplate.sendBody("direct:start", new ByteArrayInputStream("{\"field1\":\"value1\"}".getBytes()));
+
+        MockEndpoint.assertIsSatisfied(camelContext);
+        final Object body = result.getExchanges().get(0).getIn().getBody();
+        assertEquals(Pojo.class, body.getClass());
+        assertEquals("value1", ((Pojo) body).getField1());
+    }
+
+}

--- a/src/test/java/org/apache/camel/component/atlasmap/Pojo.java
+++ b/src/test/java/org/apache/camel/component/atlasmap/Pojo.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.component.atlasmap;
+
+public class Pojo {
+
+    private String field1;
+
+    public String getField1() {
+        return field1;
+    }
+
+    public void setField1(final String field1) {
+        this.field1 = field1;
+    }
+
+}

--- a/src/test/resources/atlasmapping-json-to-java.json
+++ b/src/test/resources/atlasmapping-json-to-java.json
@@ -1,0 +1,54 @@
+{
+    "AtlasMapping": {
+        "jsonType": "io.atlasmap.v2.AtlasMapping",
+        "dataSource": [
+            {
+                "jsonType": "io.atlasmap.json.v2.JsonDataSource",
+                "id": "Contact",
+                "uri": "atlas:json:Json",
+                "dataSourceType": "SOURCE",
+                "template": null
+            },
+            {
+                "jsonType": "io.atlasmap.v2.DataSource",
+                "id": "twitter4j.Status",
+                "uri": "atlas:java?className=org.apache.camel.component.atlasmap.Pojo",
+                "dataSourceType": "TARGET"
+            }
+        ],
+        "mappings": {
+            "mapping": [
+                {
+                    "jsonType": "io.atlasmap.v2.Mapping",
+                    "mappingType": "MAP",
+                    "inputField": [
+                        {
+                            "jsonType": "io.atlasmap.json.v2.JsonComplexType",
+                            "name": "field1",
+                            "path": "/field1",
+                            "fieldType": "STRING",
+                            "docId": "Json",
+                            "userCreated": false
+                        }
+                    ],
+                    "outputField": [
+                        {
+                            "jsonType": "io.atlasmap.java.v2.JavaField",
+                            "name": "field1",
+                            "path": "/field1",
+                            "fieldType": "STRING",
+                            "docId": "org.apache.camel.component.atlasmap.Pojo"
+                        }
+                    ]
+                }
+            ]
+        },
+        "name": "UI.246440",
+        "lookupTables": {
+            "lookupTable": []
+        },
+        "properties": {
+            "property": []
+        }
+    }
+}

--- a/src/test/resources/org/apache/camel/component/atlasmap/AtlasMapComponentJsonToJavaTest-context.xml
+++ b/src/test/resources/org/apache/camel/component/atlasmap/AtlasMapComponentJsonToJavaTest-context.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <route>
+            <from uri="direct:start" />
+            <to uri="atlas:atlasmapping-json-to-java.json" />
+            <to uri="mock:result" />
+        </route>
+    </camelContext>
+
+</beans>


### PR DESCRIPTION
This is a quick fix for #26, given an InputStream in the incoming
message body then read it into the String and pass that along to the
mapping engine as the parsers (JSON, XML) expect body to be String
based.

Fixes #26