### PR TITLE
chore(dependency): upgrade Camel to newest Fuse EA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <camel.osgi.export.pkg>org.apache.camel.converter.atlasmap.*</camel.osgi.export.pkg>
         <camel.osgi.export.service>org.apache.camel.spi.DataFormatResolver;dataformat=atlasmap</camel.osgi.export.service>
         <atlas.version>1.30.0</atlas.version>
-        <camel.version>2.19.2</camel.version>
+        <camel.version>2.20.0.fuse-000106</camel.version>
         <ipaas.connector.version>0.4.5</ipaas.connector.version>
         <jaxb.version>2.2.11</jaxb.version>
         <junit.version>4.12</junit.version>
@@ -59,7 +59,35 @@
         <connection>scm:git:git://github.com/atlasmap/camel-atlasmap.git</connection>
         <developerConnection>scm:git:git@github.com:atlasmap/camel-atlasmap.git</developerConnection>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
+
+    <repositories>
+      <repository>
+        <id>jboss-ea</id>
+        <name>JBoss Early-access repository</name>
+        <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
+        <releases>
+          <enabled>true</enabled>
+        </releases>
+        <snapshots>
+          <enabled>false</enabled>
+        </snapshots>
+      </repository>    
+    </repositories>
+
+    <pluginRepositories>
+      <pluginRepository>
+        <id>jboss-ea</id>
+        <name>JBoss Early-access repository</name>
+        <url>https://repository.jboss.org/nexus/content/groups/ea/</url>
+        <releases>
+          <enabled>true</enabled>
+        </releases>
+        <snapshots>
+          <enabled>false</enabled>
+        </snapshots>
+      </pluginRepository>    
+    </pluginRepositories>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
This changes the version of Camel being used to the version from Fuse
early access builds. It also adds a repository so that those
dependencies can be fetched.